### PR TITLE
Add pre-commit/prek hook definitions with docs and end-to-end tests

### DIFF
--- a/.github/workflows/pre-commit-hook-test.yml
+++ b/.github/workflows/pre-commit-hook-test.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+permissions:
+  contents: read
+name: Pre-commit Hook Test
+jobs:
+  hook-test:
+    runs-on: ubuntu-latest
+    name: Test pre-commit hook
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.26.x
+      - name: Install Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+      - name: Test hook
+        run: ./test-pre-commit-hook.sh

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,18 @@
+- id: gotmplfmt
+  name: gotmplfmt
+  description: Format Go templates
+  entry: gotmplfmt
+  args:
+    - "-w"
+  language: golang
+  types_or: [html, xml, svg, plain-text]
+- id: gotmplfmt-recursive
+  name: gotmplfmt-recursive
+  description: Format Go templates
+  entry: gotmplfmt
+  args:
+    - "-w"
+    - .
+  pass_filenames: false
+  language: golang
+  types_or: [text]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ go install github.com/gohugoio/gotmplfmt@latest
 
 For the VS Code extension, see [here](vscode/README.md)
 
+### pre-commit
+
+You can also use `gotmplfmt` as a [pre-commit](https://pre-commit.com/) / [prek](https://prek.j178.dev/) hook.
+
+```yaml
+- repo: https://github.com/gohugoio/gotmplfmt
+  rev: {vX.Y.Z, sha}
+  hooks:
+    - id: gotmplfmt
+```
+
+If you want to run recursively from the repository root instead of receiving file arguments from pre-commit, use:
+
+```yaml
+- repo: https://github.com/gohugoio/gotmplfmt
+  rev: {vX.Y.Z, sha}
+  hooks:
+    - id: gotmplfmt-recursive
+```
+
 ## License
 
 For the license for this code, please see the LICENSE file.

--- a/test-pre-commit-hook.sh
+++ b/test-pre-commit-hook.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -o errtrace -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+MOCK_REPO="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$MOCK_REPO"
+}
+
+trap cleanup EXIT
+
+init_repo() {
+	local repo_dir="$1"
+	mkdir -p "$repo_dir"
+	pushd "$repo_dir" >/dev/null
+	git init --initial-branch=main
+	git config user.email "test@example.com"
+	git config user.name "pre-commit test"
+	popd >/dev/null
+}
+
+run_hook_expect_changes() {
+	local repo_dir="$1"
+	local hook_id="$2"
+
+	pushd "$repo_dir" >/dev/null
+	set +e
+	pre-commit try-repo "$SCRIPT_DIR" "$hook_id" --verbose --all-files
+	status=$?
+	set -e
+
+	if [[ $status -eq 0 ]]; then
+		echo "expected $hook_id to report modifications"
+		exit 1
+	fi
+	popd >/dev/null
+}
+
+run_hook_expect_success() {
+	local repo_dir="$1"
+	local hook_id="$2"
+
+	pushd "$repo_dir" >/dev/null
+	pre-commit try-repo "$SCRIPT_DIR" "$hook_id" --verbose --all-files
+	popd >/dev/null
+}
+
+single_repo="$MOCK_REPO/single"
+init_repo "$single_repo"
+pushd "$single_repo" >/dev/null
+
+cp "$SCRIPT_DIR/internal/format/golden/in/else-if.html" index.html
+cp "$SCRIPT_DIR/internal/format/golden/out/else-if.html" expected.html
+
+git add .
+git commit -m "Initial commit"
+popd >/dev/null
+
+run_hook_expect_changes "$single_repo" gotmplfmt
+
+pushd "$single_repo" >/dev/null
+cmp index.html expected.html
+popd >/dev/null
+
+recursive_repo="$MOCK_REPO/recursive"
+init_repo "$recursive_repo"
+pushd "$recursive_repo" >/dev/null
+mkdir -p templates
+cp "$SCRIPT_DIR/internal/format/golden/out/else-if.html" templates/page.html
+
+git add .
+git commit -m "Initial commit"
+popd >/dev/null
+
+run_hook_expect_success "$recursive_repo" gotmplfmt-recursive
+
+pushd "$recursive_repo" >/dev/null
+cmp templates/page.html "$SCRIPT_DIR/internal/format/golden/out/else-if.html"
+popd >/dev/null


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) / [prek](https://prek.j178.dev/) is a widely used framework for running linters and formatters via [hooks](https://pre-commit.com/hooks.html) across languages. It can be used as a git hook or run manually with `pre-commit run -a`. pre-commit manages hook dependencies in isolated environments and caches installations per `rev`.

This change adds `.pre-commit-hooks.yaml` (plus documentation and CI/e2e validation), so other projects can run `gotmplfmt` directly via pre-commit.