### PR TITLE
Add -l and -d flags for CI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,40 @@ To use this as a CLI tool, you can run:
 go install github.com/gohugoio/gotmplfmt@latest
 ```
 
+```
+usage: gotmplfmt [flags] [path ...]
+
+  -d	display diffs instead of rewriting files
+  -l	list files whose formatting differs from gotmplfmt's
+  -w	write result to (source) file instead of stdout
+```
+
+Without flags, `gotmplfmt` prints the formatted output to stdout. When given a directory, it processes all template files (`.html`, `.htm`, `.xml`, `.svg`, `.rss`, `.atom`, `.txt`) recursively. It also reads from stdin when no paths are given.
+
+### CI
+
+To check that all files are formatted in CI, you can use the `-l` flag:
+
+```
+gotmplfmt -l . | grep . && exit 1
+```
+
+Or use `-d` to display the diffs:
+
+```
+gotmplfmt -d .
+```
+
+In a GitHub Actions, you may want to add something like these steps to your workflow:
+
+```yaml
+steps:
+  - name: Install gotmplfmt
+    run: go install github.com/gohugoio/gotmplfmt@latest
+  - name: Check go template formatting
+    run: "diff <(gotmplfmt -d layouts) <(printf '')"
+```
+
 For the VS Code extension, see [here](vscode/README.md)
 
 ## License

--- a/main.go
+++ b/main.go
@@ -11,9 +11,14 @@ import (
 	"strings"
 
 	"github.com/gohugoio/gotmplfmt/internal/format"
+	"github.com/rogpeppe/go-internal/diff"
 )
 
-var writeFlag = flag.Bool("w", false, "write result to (source) file instead of stdout")
+var (
+	writeFlag = flag.Bool("w", false, "write result to (source) file instead of stdout")
+	listFlag  = flag.Bool("l", false, "list files whose formatting differs from gotmplfmt's")
+	diffFlag  = flag.Bool("d", false, "display diffs instead of rewriting files")
+)
 
 func main() {
 	log.SetFlags(0)
@@ -26,6 +31,9 @@ func main() {
 	if flag.NArg() == 0 {
 		if *writeFlag {
 			log.Fatal("error: cannot use -w with standard input")
+		}
+		if *listFlag {
+			log.Fatal("error: cannot use -l with standard input")
 		}
 		if err := processReader(os.Stdin, os.Stdout); err != nil {
 			log.Fatal(err)
@@ -70,6 +78,19 @@ func processFile(path string) error {
 	out, err := format.Format(string(src))
 	if err != nil {
 		return fmt.Errorf("%s: %w", path, err)
+	}
+	if *listFlag {
+		if out != string(src) {
+			fmt.Println(path)
+		}
+		return nil
+	}
+	if *diffFlag {
+		if out != string(src) {
+			d := diff.Diff(path+".orig", src, path, []byte(out))
+			os.Stdout.Write(d)
+		}
+		return nil
 	}
 	if *writeFlag {
 		if out == string(src) {

--- a/testscripts/diff-flag.txt
+++ b/testscripts/diff-flag.txt
@@ -1,0 +1,25 @@
+# Test -d flag displays diffs.
+
+gotmplfmt -d unformatted.html
+stdout 'diff'
+stdout '-  <span>hello</span>'
+
+# No diff output for already formatted files.
+gotmplfmt -d formatted.html
+! stdout .
+
+# Source file should be unchanged.
+cmp unformatted.html unformatted.orig.html
+
+-- unformatted.html --
+<div>
+  <span>hello</span>
+</div>
+-- unformatted.orig.html --
+<div>
+  <span>hello</span>
+</div>
+-- formatted.html --
+<div>
+	<span>hello</span>
+</div>

--- a/testscripts/list-flag.txt
+++ b/testscripts/list-flag.txt
@@ -1,0 +1,25 @@
+# Test -l flag lists files whose formatting differs.
+
+gotmplfmt -l unformatted.html formatted.html
+stdout '^unformatted.html$'
+! stdout '^formatted.html$'
+
+# Source files should be unchanged.
+cmp unformatted.html unformatted.orig.html
+
+# Test that -l with stdin fails.
+! gotmplfmt -l
+stderr 'error: cannot use -l with standard input'
+
+-- unformatted.html --
+<div>
+  <span>hello</span>
+</div>
+-- unformatted.orig.html --
+<div>
+  <span>hello</span>
+</div>
+-- formatted.html --
+<div>
+	<span>hello</span>
+</div>


### PR DESCRIPTION
-l lists files whose formatting differs, -d displays unified diffs.
Neither flag modifies source files. Update README with usage and CI examples.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
