### PR TITLE
vscode: Prompt to install gotmplfmt binary when not found

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,8 +1,14 @@
 import * as vscode from "vscode";
 import { execFile } from "child_process";
 
+const installCommand = "go install github.com/gohugoio/gotmplfmt@latest";
+
 export function activate(context: vscode.ExtensionContext) {
   const config = vscode.workspace.getConfiguration("gotmplfmt");
+  const bin = config.get<string>("path", "gotmplfmt");
+
+  checkBinaryExists(bin);
+
   const languages: string[] = config.get("languages", [
     "html",
     "gohtml",
@@ -16,6 +22,36 @@ export function activate(context: vscode.ExtensionContext) {
     );
     context.subscriptions.push(provider);
   }
+}
+
+function checkBinaryExists(bin: string) {
+  execFile(bin, ["--help"], (err) => {
+    if (!err) {
+      return;
+    }
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      return;
+    }
+    vscode.window
+      .showWarningMessage(
+        `gotmplfmt binary not found. Install it with: ${installCommand}`,
+        "Install",
+        "Configure Path"
+      )
+      .then((choice) => {
+        if (choice === "Install") {
+          const terminal = vscode.window.createTerminal("gotmplfmt");
+          terminal.show();
+          terminal.sendText(installCommand);
+        } else if (choice === "Configure Path") {
+          vscode.commands.executeCommand(
+            "workbench.action.openSettings",
+            "gotmplfmt.path"
+          );
+        }
+      });
+  });
 }
 
 export function deactivate() {}
@@ -37,8 +73,13 @@ class GotmplfmtFormatter
         { timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
         (err, stdout, stderr) => {
           if (err) {
-            const msg = stderr?.trim() || err.message;
-            vscode.window.showErrorMessage(`gotmplfmt: ${msg}`);
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code === "ENOENT") {
+              checkBinaryExists(bin);
+            } else {
+              const msg = stderr?.trim() || err.message;
+              vscode.window.showErrorMessage(`gotmplfmt: ${msg}`);
+            }
             return resolve([]);
           }
           if (stdout === text) {


### PR DESCRIPTION
On activation, check if the binary exists. If not, show a warning
with "Install" (runs go install in a terminal) and "Configure Path"
buttons. The same prompt is shown if formatting fails due to a
missing binary.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
